### PR TITLE
Add OS and arch to artifact

### DIFF
--- a/prog/weavewait/build.sh
+++ b/prog/weavewait/build.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-go build -ldflags "-X github.com/weaveworks/weave/net.VethName=eth0 -linkmode external -extldflags -static -s" -tags iface -o r
+OS="$(uname -s)"
+ARCH="$(uname -m)"
 
+go build -ldflags "-X github.com/weaveworks/weave/net.VethName=eth0 -linkmode external -extldflags -static -s" -tags iface -o "r-$OS-$ARCH"


### PR DESCRIPTION
Builds on `x86_64`, `ppc64le`, `armv6l`, and `armv7l` (`cd prog/weavewait && ./build.sh`).